### PR TITLE
Removed count_only from params

### DIFF
--- a/pdl-specs.json
+++ b/pdl-specs.json
@@ -8403,15 +8403,6 @@
                         }
                     },
                     {
-                        "name": "count_only",
-                        "in": "query",
-                        "description": "Setting count_only to true will return only the total number of records that would be returned if the query was run. Available for paid plans only.",
-                        "schema": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    },
-                    {
                         "name": "scroll_token",
                         "in": "query",
                         "description": "An offset key for paginating between batches. Can be used for any number of records. Each search API response returns a scroll_token which can be used to fetch the next size records.",
@@ -8523,12 +8514,7 @@
                                         "format": "int32",
                                         "default": 1
                                     },
-                                    "count_only": {
-                                        "type": "boolean",
-                                        "description": "Setting count_only to true will return only the total number of records that would be returned if the query was run. Available for paid plans only.",
-                                        "default": false
-                                    },
-                                    "from": {
+                                   "from": {
                                         "type": "integer",
                                         "description": "An offset value for pagination. Can be a number between 0 and 9999. Pagination can be executed up to a maximum of 10,000 records per query. Be sure to use the \"total\" response field to help discover how many total records exist in the dataset for your query",
                                         "maximum": 9999,
@@ -9477,15 +9463,6 @@
                         }
                     },
                     {
-                        "name": "count_only",
-                        "in": "query",
-                        "description": "Setting count_only to true will return only the total number of records that would be returned if the query was run. Available for paid plans only.",
-                        "schema": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    },
-                    {
                         "name": "from",
                         "in": "query",
                         "description": "An offset value for pagination. Can be a number between 0 and 9999. Pagination can be executed up to a maximum of 10,000 records per query. Be sure to use the \"total\" response field to help discover how many total records exist in the dataset for your query",
@@ -9590,11 +9567,6 @@
                                         "minimum": 1,
                                         "format": "int32",
                                         "default": 1
-                                    },
-                                    "count_only": {
-                                        "type": "boolean",
-                                        "description": "Setting count_only to true will return only the total number of records that would be returned if the query was run. Available for paid plans only.",
-                                        "default": false
                                     },
                                     "from": {
                                         "type": "integer",


### PR DESCRIPTION
## Description of the change

- Removed count_only param from Company and Person GET and POST endpoints

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Chore (cleanup or minor QOL tweak that has little to no impact on functionality)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
